### PR TITLE
Pin pnpm and approve build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "blog",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@11.5.3",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Pins pnpm to match gallery and adds the same pnpm-workspace.yaml allowBuilds configuration.

Verified with: CI=true corepack pnpm install --frozen-lockfile && corepack pnpm build